### PR TITLE
增加bodyparse可配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,18 @@ module.exports = proxy;
 
 - `proxy` => `{}` Proxy settings.
 - `changeHost` => `{}` Setting req headers host.
-- `httpProxy` => `{}` Set the [listen event](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events) and [configuration](https://github.com/nodejitsu/node-http-proxy#options) of [http-proxy](https://github.com/nodejitsu/node-http-proxy)
+- `httpProxy` => `{}` Set the [listen event](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events) and [configuration](https://github.com/nodejitsu/node-http-proxy#options) of [http-proxy](https://github.com/nodejitsu/node-http-proxy)    
+- [`bodyParserJSON`](https://github.com/expressjs/body-parser/tree/56a2b73c26b2238bc3050ad90af9ab9c62f4eb97#bodyparserjsonoptions) JSON body parser
 - [`bodyParserJSON`](https://github.com/expressjs/body-parser/tree/56a2b73c26b2238bc3050ad90af9ab9c62f4eb97#bodyparserjsonoptions) JSON body parser
 - [`bodyParserText`](https://github.com/expressjs/body-parser/tree/56a2b73c26b2238bc3050ad90af9ab9c62f4eb97#bodyparsertextoptions) Text body parser
 - [`bodyParserRaw`](https://github.com/expressjs/body-parser/tree/56a2b73c26b2238bc3050ad90af9ab9c62f4eb97#bodyparserrawoptions) Raw body parser
 - [`bodyParserUrlencoded`](https://github.com/expressjs/body-parser/tree/56a2b73c26b2238bc3050ad90af9ab9c62f4eb97#bodyparserurlencodedoptions) URL-encoded form body parser
-
-## Delayed Response
+- `bodyParserConf` => `{}` bodyParser settings. eg：
+`
+bodyParserConf : {'text/plain': 'text','text/html': 'text'}
+`
+will parsed `Content-Type='text/plain' and Content-Type='text/html'` with `bodyParser.text`  
+## Delayed Responsev
 
 You can use functional tool to enhance mock. [#17](https://github.com/jaywcjlove/webpack-api-mocker/issues/17)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14094844/56199954-79592600-6070-11e9-97d2-7134ca562d68.png)
当我遇到这种情况是，需要配置bodyParserConf: {'text/plain' : 'json'} 来解析。每个公司的业务会根据有自己的协议，'text/plain' 固定死使用 raw来解析，感觉不太合理。