### PR TITLE
Add CORS header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,8 @@ module.exports = function (app, watchFile, conf = {}) {
     });
 
     if (mocker[mockerKey]) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+
       let bodyParserMethd = bodyParser.json({ ...bodyParserJSON });//默认使用json解析
       const contentType = req.get('Content-Type');
       if(bodyParserConf && bodyParserConf[contentType]) { // 如果存在bodyParserConf配置 {'text/plain': 'text','text/html': 'text'}


### PR DESCRIPTION
If webpack is serving the mock API from one domain, but another domain is trying to use this mock-api -> the CORS headers are missing hence it doesn't work.

This fixes the issue. Any domain will be able to use the local mocker-api.