### PR TITLE
feat: 自动添加 access-control-request-headers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -291,7 +291,7 @@ export default function (app: Application, watchFile: string | string[] | Mocker
     const accessOptions: MockerOption['header'] = {
       'Access-Control-Allow-Origin': req.get('Origin') || '*',
       'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, PUT, DELETE',
-      'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With',
+      'Access-Control-Allow-Headers': 'Content-Type, X-Requested-With,' + (req.header('access-control-request-headers') || ''),
       'Access-Control-Allow-Credentials': 'true',
       ...options.header,
     }


### PR DESCRIPTION
在有自定义header时，会抛出跨域错误, 提个pr改成自动获取 😄 
![image](https://user-images.githubusercontent.com/14126445/99373069-f22efc80-28fb-11eb-9ee6-97c63e2b4e97.png)
