### PR TITLE
fix(deps): Upgrades path-to-regexp to 8.4.2 [security]

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "http-proxy": "~1.18.1",
     "local-ip-url": "~1.0.3",
     "minimist": "~1.2.7",
-    "path-to-regexp": "~8.2.0"
+    "path-to-regexp": "~8.4.2"
   },
   "devDependencies": {
     "@types/express": "~5.0.6",


### PR DESCRIPTION
versions of `path-to-regexp` <8.4.0 and >=8.0.0 are vulnerable to ReDos:

https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-15789765
https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-15789763